### PR TITLE
Refactor out a SmartAppConfigManager that can be overridden

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.5.0     unreleased
+
+	* Refactor out a SmartAppConfigManager that can be overridden.
+
 Version 0.4.1     19 Jun 2022
 
 	* Updates to published documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smartapp-sdk"
-version = "0.4.1"
+version = "0.5.0a1"
 description = "Framework to build a webhook-based SmartThings SmartApp"
 authors = ["Kenneth J. Pronovici <pronovic@ieee.org>"]
 license = "Apache-2.0"

--- a/src/smartapp/dispatcher.py
+++ b/src/smartapp/dispatcher.py
@@ -56,7 +56,7 @@ class StaticConfigManager(SmartAppConfigManager):
     manager with that specialized behavior.
     """
 
-    def handle_page(self, definition: SmartAppDefinition, page_id: int) -> ConfigurationPageResponse:
+    def handle_page(self, request: ConfigurationRequest, definition: SmartAppDefinition, page_id: int) -> ConfigurationPageResponse:
         """Handle a CONFIGURATION PAGE lifecycle request."""
         if not definition.config_pages:
             raise ValueError("Static configuration manager requires at least one configured page.")
@@ -166,7 +166,7 @@ class SmartAppDispatcher:
     def _handle_config_request(self, request: ConfigurationRequest) -> Union[ConfigurationInitResponse, ConfigurationPageResponse]:
         """Handle a CONFIGURATION lifecycle request, returning an appropriate response."""
         if request.configuration_data.phase == ConfigPhase.INITIALIZE:
-            return self.manager.handle_initialize(self.definition)
+            return self.manager.handle_initialize(request, self.definition)
         else:  # if request.configuration_data.phase == ConfigPhase.PAGE:
             page_id = int(request.configuration_data.page_id)
-            return self.manager.handle_page(self.definition, page_id)
+            return self.manager.handle_page(request, self.definition, page_id)

--- a/src/smartapp/interface.py
+++ b/src/smartapp/interface.py
@@ -999,7 +999,77 @@ class SmartAppDefinition:
     description: str
     target_url: str
     permissions: List[str]
-    config_pages: List[SmartAppConfigPage]
+    config_pages: Optional[List[SmartAppConfigPage]]
+
+
+# pylint: disable=redefined-builtin:
+# noinspection PyShadowingBuiltins,PyMethodMayBeStatic
+class SmartAppConfigManager(ABC):
+    """
+    Configuration manager, used by the dispatcher to respond to CONFIGURATION events.
+
+    The dispatcher has a default configuration manager.  However, you can implement your
+    own if that default behavior does not meet your needs.  For instance, a static config
+    definition is adequate for lots of SmartApps, but it doesn't work for some types of
+    complex configuration, where the responses need to be generated dynamically.  In that
+    case, you can implement your own configuration manager with that specialized behavior.
+
+    This abstract class also includes several convenience methods to make it easier to
+    build responses.
+    """
+
+    def handle_initialize(self, definition: SmartAppDefinition) -> ConfigurationInitResponse:
+        """Handle a CONFIGURATION INITIALIZE lifecycle request."""
+        return self.build_init_response(
+            id=definition.id,
+            name=definition.name,
+            description=definition.description,
+            permissions=definition.permissions,
+            first_page_id=1,
+        )
+
+    @abstractmethod
+    def handle_page(self, definition: SmartAppDefinition, page_id: int) -> ConfigurationPageResponse:
+        """Handle a CONFIGURATION PAGE lifecycle request."""
+
+    def build_init_response(
+        self, id: str, name: str, description: str, permissions: List[str], first_page_id: int
+    ) -> ConfigurationInitResponse:
+        """Build a ConfigurationInitResponse."""
+        return ConfigurationInitResponse(
+            configuration_data=ConfigInitData(
+                initialize=ConfigInit(
+                    id=id,
+                    name=name,
+                    description=description,
+                    permissions=permissions,
+                    first_page_id=str(first_page_id),
+                )
+            )
+        )
+
+    def build_page_response(
+        self,
+        page_id: int,
+        name: str,
+        previous_page_id: Optional[int],
+        next_page_id: Optional[int],
+        complete: bool,
+        sections: List[ConfigSection],
+    ) -> ConfigurationPageResponse:
+        """Build a ConfigurationPageResponse."""
+        return ConfigurationPageResponse(
+            configuration_data=ConfigPageData(
+                page=ConfigPage(
+                    name=name,
+                    page_id=str(page_id),
+                    previous_page_id=str(previous_page_id) if previous_page_id else None,
+                    next_page_id=str(next_page_id) if next_page_id else None,
+                    complete=complete,
+                    sections=sections,
+                )
+            )
+        )
 
 
 # noinspection PyUnresolvedReferences

--- a/src/smartapp/interface.py
+++ b/src/smartapp/interface.py
@@ -1002,7 +1002,7 @@ class SmartAppDefinition:
     config_pages: Optional[List[SmartAppConfigPage]]
 
 
-# pylint: disable=redefined-builtin:
+# pylint: disable=redefined-builtin,unused-argument:
 # noinspection PyShadowingBuiltins,PyMethodMayBeStatic
 class SmartAppConfigManager(ABC):
     """
@@ -1018,7 +1018,7 @@ class SmartAppConfigManager(ABC):
     build responses.
     """
 
-    def handle_initialize(self, definition: SmartAppDefinition) -> ConfigurationInitResponse:
+    def handle_initialize(self, request: ConfigurationRequest, definition: SmartAppDefinition) -> ConfigurationInitResponse:
         """Handle a CONFIGURATION INITIALIZE lifecycle request."""
         return self.build_init_response(
             id=definition.id,
@@ -1029,7 +1029,7 @@ class SmartAppConfigManager(ABC):
         )
 
     @abstractmethod
-    def handle_page(self, definition: SmartAppDefinition, page_id: int) -> ConfigurationPageResponse:
+    def handle_page(self, request: ConfigurationRequest, definition: SmartAppDefinition, page_id: int) -> ConfigurationPageResponse:
         """Handle a CONFIGURATION PAGE lifecycle request."""
 
     def build_init_response(


### PR DESCRIPTION
The default behavior with a static set of configuration pages is ok for most SmartApps, but some might need to generate dynamic responses.  This PR refactors out `SmartAppConfigManager` abstract class and adds a `manager` attribute on the dispatcher, so the behavior can be configured at runtime if necessary.