### PR TITLE
Rewrite tests to use the responses framework

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1086,6 +1086,27 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.22.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
+    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+
+[package.dependencies]
+requests = ">=2.22.0,<3.0"
+toml = "*"
+types-toml = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
+
+[[package]]
 name = "setuptools"
 version = "67.4.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1297,6 +1318,18 @@ files = [
 doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1346,6 +1379,18 @@ files = [
 
 [package.dependencies]
 types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.5"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-toml-0.10.8.5.tar.gz", hash = "sha256:bf80fce7d2d74be91148f47b88d9ae5adeb1024abef22aa2fdbabc036d6b8b3c"},
+    {file = "types_toml-0.10.8.5-py3-none-any.whl", hash = "sha256:2432017febe43174af0f3c65f03116e3d3cf43e7e1406b8200e106da8cf98992"},
+]
 
 [[package]]
 name = "types-urllib3"
@@ -1517,4 +1562,4 @@ docs = ["importlib-metadata", "sphinx", "sphinx-autoapi"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "1500bd52ecd0dc6c03c956d32b77316e596788f756f9526d92baf70961250da0"
+content-hash = "f456125010514ee0937c7545d0525ca13c9c07eaeeff716480dc2a91062b20a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ coveralls = "^3.3.1"
 types-PyYAML = "^6.0.12.8"
 types-requests = "^2.28.11.15"
 colorama = "~0, >=0.4.6"
-responses = "^0.22.0"
+responses = "~0, >=0.22.0"
 
 [tool.black]
 line-length = 132

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ coveralls = "^3.3.1"
 types-PyYAML = "^6.0.12.8"
 types-requests = "^2.28.11.15"
 colorama = "~0, >=0.4.6"
+responses = "^0.22.0"
 
 [tool.black]
 line-length = 132


### PR DESCRIPTION
The unit tests for web client code (that rely on mocking the requests framework) have historically been pretty awkward.  It takes a bunch of code to set up the responses and check the correct behavior.  It turns out that frameworks have been written to simplify this.  Two of these are [responses](https://pypi.org/project/responses/) and [requests-mock](https://pypi.org/project/requests-mock/).  I experimented with both, and found that I preferred responses, so I have rewritten all of the tests to use it.  The framework lets you stub out responses from the server (much like wiremock for Java) and also automatically fails a test if an expected stub isn't invoked.  I think that the tests are more legible now, and they should be easier to maintain.