### PR TITLE
Fix bug in serializing BooleanSetting to and from YAML

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Version 0.7.0     unreleased
 	* Move configuration into pyproject.toml for pytest, mypy & coverage.
 	* Upgrade to gha-shared-workflows@v8 for Poetry v2 support.
 	* Migrate from pendulum to arrow for dates (interface change).
+	* Fix bug in serializing BooleanSetting to and from YAML.
 	* Update all dependencies and outdated constraints.
 
 Version 0.6.9     02 Jan 2025

--- a/src/smartapp/converter.py
+++ b/src/smartapp/converter.py
@@ -6,6 +6,7 @@
 Converter to serialize and deserialize lifecycle objects to various formats.
 """
 import json
+from enum import Enum
 from typing import Any, Dict, Type, TypeVar
 
 import yaml
@@ -15,6 +16,7 @@ from arrow import now as arrow_now
 from attrs import fields, has
 from cattrs import GenConverter
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
+from yaml import SafeDumper
 
 from .interface import (
     CONFIG_SETTING_BY_TYPE,
@@ -39,6 +41,10 @@ DATETIME_MS_LEN = len("YYYY-MM-DDTHH:MM:SS.SSSZ")  # like "2017-09-13T04:18:12.9
 DATETIME_MS_FORMAT = "YYYY-MM-DD[T]HH:mm:ss.SSS[Z]"
 
 T = TypeVar("T")  # pylint: disable=invalid-name:
+
+
+# Configure SafeDumper to handle Enum values
+yaml.add_multi_representer(Enum, lambda d, e: d.represent_str(e.value), Dumper=SafeDumper)
 
 
 def serialize_datetime(datetime: Arrow) -> str:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -106,7 +106,7 @@ class TestConvertSettings:
             name="True or false?",
             description="Tap to set",
             required=True,
-            default_value="true",
+            default_value=BooleanValue.TRUE,
         )
         validate_json_roundtrip(json, expected, BooleanSetting)
         validate_yaml_roundtrip(None, expected, BooleanSetting)


### PR DESCRIPTION
While working on PR #22, I noticed a warning in PyCharm about the wrong type of argument being passed to `BooleanSetting`.  That oversight was masking a problem serializing enumerations like `BooleanValue` to YAML.