### PR TITLE
Add notes in documentation that I no longer use SmartThings

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,10 +3,8 @@ Version 0.7.1     unreleased
 	* Pull in latest version of run-script-framework.
 	* Upgrade to poetry-dynamic-versioning v1.5.2 for minor fixes.
 	* Add .python-version in preferred order to support pyenv.
-
-Version 0.7.1     unreleased
-
 	* Adjust pyproject.toml comments to fix pip build at readthedocs.
+	* Add notes in documentation that I no longer use SmartThings.
 
 Version 0.7.0     08 Jan 2025
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -9,7 +9,7 @@
 [![coverage](https://coveralls.io/repos/github/pronovic/smartapp-sdk/badge.svg?branch=main)](https://coveralls.io/github/pronovic/smartapp-sdk?branch=main)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 
-_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date, and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
+_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
 
 ---
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -9,10 +9,14 @@
 [![coverage](https://coveralls.io/repos/github/pronovic/smartapp-sdk/badge.svg?branch=main)](https://coveralls.io/github/pronovic/smartapp-sdk?branch=main)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 
+_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date, and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
+
+---
+
 smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer-preview.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
 
 The SDK is intended to be easy to use no matter how you choose to structure your code, whether that's a traditional Python webapp (such as FastAPI on Uvicorn) or a serverless application (such as AWS Lambda).
 
 The SDK handles all the mechanics of the [webhook lifecycle interface](https://developer-preview.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.
 
-SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code. The [smartapp-sensortrack](https://github.com/pronovic/smartapp-sensortrack) repo on GitHub is also a good example of how to use this SDK to build a traditional Python webapp.
+SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![coverage](https://coveralls.io/repos/github/pronovic/smartapp-sdk/badge.svg?branch=main)](https://coveralls.io/github/pronovic/smartapp-sdk?branch=main)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 
-_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date, and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
+_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@
 [![coverage](https://coveralls.io/repos/github/pronovic/smartapp-sdk/badge.svg?branch=main)](https://coveralls.io/github/pronovic/smartapp-sdk?branch=main)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 
+_Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date, and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes._
+
+---
+
 smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer-preview.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
 
 The SDK is intended to be easy to use no matter how you choose to structure your code, whether that's a traditional Python webapp (such as FastAPI on Uvicorn) or a serverless application (such as AWS Lambda).
 
 The SDK handles all the mechanics of the [webhook lifecycle interface](https://developer-preview.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.
 
-SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.  The [smartapp-sensortrack](https://github.com/pronovic/smartapp-sensortrack) repo on GitHub is also a good example of how to use this SDK to build a traditional Python webapp.
+SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.
 
 Developer documentation for the smartapp-sdk repo is found in [DEVELOPER.md](DEVELOPER.md).  See that file for notes about how the code is structured, how to set up a development environment, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,8 @@ This repository uses [Semantic Versioning](https://semver.org/).  The latest MAJ
 ## Reporting a Vulnerability
 
 To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/pronovic/smartapp-sdk/security/advisories/new) tab.
+
+## Testing Expectations
+
+As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,8 @@ The SDK is intended to be easy to use no matter how you choose to structure your
 The SDK handles all the mechanics of the `webhook lifecycle interface <https://developer-preview.smartthings.com/docs/connected-serv
 ices/lifecycles/>`_ on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callba ck class where you define specialized behavior for the webhook events.  A clean `attrs <https://www.attrs.org/en/stable/>`_ object interface is exposed for use by your callback.
 
+*Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes.*
+
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ API Documentation
 Using the SDK
 -------------
 
-Below are some notes on how to use the SDK.  The `smartapp-sensortrack <https://github.com/pronovic/smartapp-sensortrack>`_ repo on GitHub is also a good example of how to use the SDK to build a traditional Python webapp.
+Below are some notes on how to use the SDK.
 
 Event Handler
 ~~~~~~~~~~~~~
@@ -236,4 +236,4 @@ for the installed application.  So, if your SmartApp is built around event
 handling and scheduled actions triggered by SmartThings, your handler can
 probably be stateless.  There is probably is not any need to persist any of the
 data returned in the ``INSTALL`` or ``UPDATE`` lifecycle events into your own
-data store.  This is the model folowed in the `smartapp-sensortrack <https://github.com/pronovic/smartapp-sensortrack>`_ example.
+data store.


### PR DESCRIPTION
As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  This PR adjusts the documentation to reflect the new state.