### PR TITLE
Update the MyPy configuration so we're using latest rules

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Version 0.7.2     unreleased
 	* Adjust GHA build process to allow builds for stacked PRs.
 	* Add a new `run clean` target to clean up generated data.
 	* Move unit tests from `tests` into `src/tests/smartapp`.
+	* Update the MyPy configuration so we're using latest rules.
 	* Update the jinja2 transitive dependency to address CVE-2025-27516.
 	* Update the requests transitive dependency to address CVE-2024-47081.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,3 @@ warn_unreachable = true
 module = "tests.*"
 check_untyped_defs = false
 allow_untyped_defs = true
-
-# There is no type hinting for pytest
-[[tool.mypy.overrides]]
-module = "pytest"
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,12 +117,12 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-# Settings are mostly equivalent to strict=true as of v1.14.1
+files = [ "src" ]
 pretty = true
 show_absolute_path = true
 show_column_numbers = true
 show_error_codes = true
-files = [ "src" ]
+# Settings equivalent to strict=true as of v1.17.1
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
@@ -130,15 +130,18 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = false
 disallow_untyped_defs = true
-no_implicit_optional = true
+extra_checks = true
 no_implicit_reexport = true
 strict_equality = true
-strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_no_return = true
 warn_unused_configs = true
 warn_unused_ignores = true
+# Additional settings above and beyond strict=true
+implicit_optional = false
+strict_optional = true
+warn_no_return = true
+warn_unreachable = true
 
 # It's hard to make tests compliant using unittest.mock
 [[tool.mypy.overrides]]

--- a/src/smartapp/interface.py
+++ b/src/smartapp/interface.py
@@ -30,6 +30,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 from arrow import Arrow
 from attrs import field, frozen
+from typing_extensions import assert_never
 
 AUTHORIZATION_HEADER = "authorization"
 CORRELATION_ID_HEADER = "x-st-correlation"
@@ -402,7 +403,7 @@ class Event:
             return self.timer_event
         elif event_type == EventType.WEATHER_EVENT:
             return self.weather_event
-        return None
+        assert_never(event_type)
 
 
 @frozen(kw_only=True)


### PR DESCRIPTION
This updates the MyPy configuration, adding a few new flags and making adjustments so it's clear which flags are related to `--strict` and which are other flags that I've added above and beyond that. Prototyped in [apologies PR #67](https://github.com/pronovic/apologies/pull/67).