### PR TITLE
Convert from old-style % formatting to f-strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,9 +164,6 @@ ignore = [
   "SIM102",     # allow nested `if` clauses; ruff suggestions often make the code less legible
   "SIM117",     # allow nested `with` clauses; ruff suggestions often make the code less legible
   "TRY003",     # allow long messages in exceptions; this is often a false-positive that has little benefit
-
-  # Exclusions of rule categories and specific rules, customized for this repository
-  "UP031",      # allow format-specifiers in addition to modern f-strings
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/smartapp/converter.py
+++ b/src/smartapp/converter.py
@@ -65,7 +65,7 @@ def deserialize_datetime(datetime: str) -> Arrow:
         return arrow_get(datetime, DATETIME_MS_FORMAT, tzinfo=DATETIME_ZONE)
     if len(datetime) == DATETIME_SEC_LEN:
         return arrow_get(datetime, DATETIME_SEC_FORMAT, tzinfo=DATETIME_ZONE)
-    raise ValueError("Unknown datetime format: %s" % datetime)
+    raise ValueError(f"Unknown datetime format: {datetime}")
 
 
 # noinspection PyMethodMayBeStatic

--- a/src/smartapp/dispatcher.py
+++ b/src/smartapp/dispatcher.py
@@ -76,7 +76,7 @@ class StaticConfigManager(SmartAppConfigManager):
                 sections=page.sections,
             )
         except IndexError as e:
-            raise ValueError("Page not found: %d" % page_id) from e
+            raise ValueError(f"Page not found: {page_id}") from e
 
 
 @frozen(kw_only=True)

--- a/src/smartapp/dispatcher.py
+++ b/src/smartapp/dispatcher.py
@@ -129,9 +129,9 @@ class SmartAppDispatcher:
         except JSONDecodeError as e:
             raise BadRequestError("Invalid JSON", context.correlation_id) from e
         except ValueError as e:
-            raise BadRequestError("%s" % e, context.correlation_id) from e
+            raise BadRequestError(f"{e}", context.correlation_id) from e
         except Exception as e:
-            raise InternalError("%s" % e, context.correlation_id) from e
+            raise InternalError(f"{e}", context.correlation_id) from e
 
     def _handle_request(self, correlation_id: str | None, request: AbstractRequest) -> LifecycleResponse:  # noqa: PLR0911
         """Handle a lifecycle request, returning the appropriate response."""

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -186,9 +186,9 @@ class SignatureVerifier:
         components = []
         for name in self.signing_headers:
             if name == "(request-target)":
-                components.append("(request-target): %s" % self.request_target)
+                components.append(f"(request-target): {self.request_target}")
             else:
-                components.append("%s: %s" % (name.lower(), self.header(name)))
+                components.append(f"{name.lower()}: {self.header(name)}")
         return "\n".join(components).rstrip("\n")
 
     def header(self, name: str) -> str:

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -119,7 +119,7 @@ class SignatureVerifier:
         parts = urllib.parse.urlsplit(self.definition.target_url)
         path = parts.path
         if parts.query:
-            path = "%s?%s" % (path, parts.query)
+            path = f"{path}?{parts.query}"
         return path
 
     @request_target.default

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -124,7 +124,7 @@ class SignatureVerifier:
 
     @request_target.default
     def _default_request_target(self) -> str:
-        return "%s %s" % (self.method.lower(), self.path)
+        return f"{self.method.lower()} {self.path}"
 
     @authorization.default
     def _default_authorization(self) -> str:

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -140,12 +140,12 @@ class SignatureVerifier:
         def attribute(name: str, default: str | None = None) -> str:
             if not self.authorization.startswith("Signature "):
                 raise SignatureError("Authorization header is not a signature", self.correlation_id)
-            pattern = r"(%s=\")([^\"]+?)(\")" % name
+            pattern = rf"({name}=\")([^\"]+?)(\")"
             match = re.search(pattern=pattern, string=self.authorization)
             if not match:
                 if default:
                     return default
-                raise SignatureError("Signature does not contain: %s" % name, self.correlation_id)
+                raise SignatureError(f"Signature does not contain: {name}", self.correlation_id)
             return match.group(2)
 
         return {

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -203,7 +203,7 @@ class SignatureVerifier:
         try:
             return retrieve_public_key(self.keyserver_url, self.key_id)  # will retry automatically
         except RequestException as e:
-            raise SignatureError("Failed to retrieve key [%s]" % self.key_id, self.correlation_id) from e
+            raise SignatureError(f"Failed to retrieve key [{self.key_id}]", self.correlation_id) from e
 
     def verify_date(self) -> None:
         """Verify the date, ensuring that it is current per skew configuration."""

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -195,7 +195,7 @@ class SignatureVerifier:
         """Return the named header case-insensitively, raising SignatureError if it is not found or is empty"""
         value = self.context.header(name)
         if not value:
-            raise SignatureError("Header not found: %s" % name, self.correlation_id)
+            raise SignatureError(f"Header not found: {name}", self.correlation_id)
         return value
 
     def retrieve_public_key(self) -> str:

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -67,7 +67,8 @@ _LOGGER = logging.getLogger(__name__)
 def retrieve_public_key(key_server_url: str, key_id: str) -> str:
     """Retrieve a public key, caching the result."""
     # Note that the key ID is assumed to be URL-safe per notes in the SmartThings spec, so we don't encode it
-    url = "%s/%s" % (key_server_url, key_id.lstrip("/"))
+    stripped = key_id.lstrip("/")
+    url = f"{key_server_url}/{stripped}"
     response = requests.get(url, timeout=5.0)  # excessively long timeout, just in case
     response.raise_for_status()
     return response.text

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -210,7 +210,7 @@ class SignatureVerifier:
         if self.config.clock_skew_sec is not None:
             skew = abs(arrow_now() - self.date)
             if skew.seconds > self.config.clock_skew_sec:
-                raise SignatureError("Request date is not current, skew of %d seconds" % skew.seconds, self.correlation_id)
+                raise SignatureError(f"Request date is not current, skew of {skew.seconds} seconds", self.correlation_id)
 
     def verify_signature(self) -> None:
         """Verify the RSA-SHA256 signature of the signing string."""

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -172,7 +172,7 @@ class SignatureVerifier:
     def _default_algorithm(self) -> str:
         algorithm = self.signing_attributes["algorithm"]
         if algorithm != "rsa-sha256":
-            raise SignatureError("Algorithm not supported: %s" % algorithm, self.correlation_id)
+            raise SignatureError(f"Algorithm not supported: {algorithm}", self.correlation_id)
         return algorithm
 
     @signature.default

--- a/src/tests/smartapp/test_converter.py
+++ b/src/tests/smartapp/test_converter.py
@@ -368,7 +368,7 @@ class TestStringSecrets:
     def test_secrets(self, requests, source):
         json = requests[source]
         request = CONVERTER.from_json(json, LifecycleRequest)
-        for string in ["%s" % request, str(request), repr(request)]:
+        for string in ["%s" % request, f"{request}", str(request), repr(request)]:  # noqa: UP031
             assert "auth_token" not in string and "authTokenValue" not in string
             assert "refresh_token" not in string and "refreshTokenValue" not in string
 

--- a/src/tests/smartapp/test_converter.py
+++ b/src/tests/smartapp/test_converter.py
@@ -150,8 +150,8 @@ class TestDatetime:
             "2017-09-13T04:18:12",  # no trailing Z
         ],
     )
-    def test_deserialize_datetim_invalid(self, datetime):
-        with pytest.raises(ValueError, match="Unknown datetime format"):
+    def test_deserialize_datetime_invalid(self, datetime):
+        with pytest.raises(ValueError, match=f"Unknown datetime format: {datetime}"):
             deserialize_datetime(datetime)
 
 

--- a/src/tests/smartapp/test_signature.py
+++ b/src/tests/smartapp/test_signature.py
@@ -85,8 +85,8 @@ KEY_ID = "Test"
 ALGORITHM = "rsa-sha256"
 CLOCK_SKEW = 300
 KEYSERVER_URL = "https://key.smartthings.com"
-KEY_DOWNLOAD_URL = "%s/%s" % (KEYSERVER_URL, KEY_ID)
-SMARTAPP_URL = "https://%s%s" % (HOST, PATH)
+KEY_DOWNLOAD_URL = f"{KEYSERVER_URL}/{KEY_ID}"
+SMARTAPP_URL = f"https://{HOST}{PATH}"
 
 # public key used for the sample Joyent signatures
 PUBLIC_SIGNING_KEY = """
@@ -263,7 +263,7 @@ class TestSignatureVerifier:
         for header in ["AUTHORIZATION", "Authorization", "authorization"]:
             assert verifier.header(header) == DEFAULT_AUTHORIZATION
         for header in ["missing", "empty", "whitespace", "none"]:
-            with pytest.raises(SignatureError, match="Header not found: %s" % header):
+            with pytest.raises(SignatureError, match=f"Header not found: {header}"):
                 verifier.header(header)
 
     @patch("smartapp.signature.arrow_now")
@@ -371,7 +371,7 @@ class TestSignatureVerifier:
         now.return_value = DATE_OBJ
         retrieve.side_effect = HTTPError("failed to download")
         verifier = SignatureVerifier(context=context, config=config, definition=definition)
-        with pytest.raises(SignatureError, match=r"Failed to retrieve key \[%s\]" % KEY_ID) as e:
+        with pytest.raises(SignatureError, match=rf"Failed to retrieve key \[{KEY_ID}\]") as e:
             verifier.verify()
         assert e.value.correlation_id == context.correlation_id
 
@@ -385,7 +385,7 @@ class TestSignatureVerifier:
         now.return_value = DATE_OBJ
         retrieve.side_effect = HTTPError("failed to download")
         verifier = SignatureVerifier(context=context, config=config, definition=definition)
-        with pytest.raises(SignatureError, match=r"Failed to retrieve key \[%s\]" % KEY_ID) as e:
+        with pytest.raises(SignatureError, match=rf"Failed to retrieve key \[{KEY_ID}\]") as e:
             verifier.verify()
         assert e.value.correlation_id == context.correlation_id
 
@@ -495,7 +495,7 @@ class TestSignatureVerifier:
         context = build_context(headers)
         config = build_config()
         definition = build_definition()
-        with pytest.raises(SignatureError, match="Signature does not contain: %s" % attribute) as e:
+        with pytest.raises(SignatureError, match=f"Signature does not contain: {attribute}") as e:
             SignatureVerifier(context=context, config=config, definition=definition)
         assert e.value.correlation_id == context.correlation_id
 


### PR DESCRIPTION
Prompted by Ruff's `UP031` linter check, this modernizes the code to consistently use f-strings instead of older-style % formatting.