### PR TITLE
Fix broken URLs to use correct hostname developer.smartthings.com

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.9.1     unreleased
+
+	* Fix broken URLs to use correct hostname `developer.smartthings.com`.
+
 Version 0.9.0     24 Sep 2025
 
 	* Pull in latest version of run-script-framework.

--- a/PyPI.md
+++ b/PyPI.md
@@ -12,10 +12,10 @@ _Note: As of January 2025, I have migrated my home automation infrastructure fro
 
 ---
 
-smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer-preview.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
+smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
 
 The SDK is intended to be easy to use no matter how you choose to structure your code, whether that's a traditional Python webapp (such as FastAPI on Uvicorn) or a serverless application (such as AWS Lambda).
 
-The SDK handles all the mechanics of the [webhook lifecycle interface](https://developer-preview.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.
+The SDK handles all the mechanics of the [SmartThings webhook lifecycle interface](https://developer.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.  The attrs interface has been designed to match the JSON interface documented by SmartThings.  If you have questions about the shape of the data or the way the lifecyle interface works, the SmartThings documentation is your best source of information.
 
-SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.
+SDK documentation for this library is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ _Note: As of January 2025, I have migrated my home automation infrastructure fro
 
 ---
 
-smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer-preview.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
+smartapp-sdk is a Python library to build a [webhook-based SmartApp](https://developer.smartthings.com/docs/connected-services/smartapp-basics/) for the [SmartThings platform](https://www.smartthings.com/).
 
 The SDK is intended to be easy to use no matter how you choose to structure your code, whether that's a traditional Python webapp (such as FastAPI on Uvicorn) or a serverless application (such as AWS Lambda).
 
-The SDK handles all the mechanics of the [webhook lifecycle interface](https://developer-preview.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.
+The SDK handles all the mechanics of the [SmartThings webhook lifecycle interface](https://developer.smartthings.com/docs/connected-services/lifecycles/) on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean [attrs](https://www.attrs.org/en/stable/) object interface is exposed for use by your callback.  The attrs interface has been designed to match the JSON interface documented by SmartThings.  If you have questions about the shape of the data or the way the lifecyle interface works, the SmartThings documentation is your best source of information.
 
-SDK documentation is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.
+SDK documentation for this library is found at [smartapp-sdk.readthedocs.io](https://smartapp-sdk.readthedocs.io/en/stable/).  Look there for installation instructions, the class model documentation, and example code.
 
 Developer documentation for the smartapp-sdk repo is found in [DEVELOPER.md](DEVELOPER.md).  See that file for notes about how the code is structured, how to set up a development environment, etc.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,13 +24,11 @@ Release v\ |version|
 .. image:: https://coveralls.io/repos/github/pronovic/smartapp-sdk/badge.svg?branch=main
     :target: https://coveralls.io/github/pronovic/smartapp-sdk?branch=main
 
-smartapp-sdk is a Python library to build a `webhook-based SmartApp <https://developer-preview.smartthings.com/docs/connected-servic
-es/smartapp-basics/>`_ for the `SmartThings platform <https://www.smartthings.com/>`_.
+smartapp-sdk is a Python library to build a `webhook-based SmartApp <https://developer.smartthings.com/docs/connected-services/smartapp-basics/>`_ for the `SmartThings platform <https://www.smartthings.com/>`_.
 
 The SDK is intended to be easy to use no matter how you choose to structure your code, whether that's a traditional Python webapp (such as FastAPI on Uvicorn) or a serverless application (such as AWS Lambda).
 
-The SDK handles all the mechanics of the `webhook lifecycle interface <https://developer-preview.smartthings.com/docs/connected-serv
-ices/lifecycles/>`_ on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callba ck class where you define specialized behavior for the webhook events.  A clean `attrs <https://www.attrs.org/en/stable/>`_ object interface is exposed for use by your callback.
+The SDK handles all the mechanics of the `SmartThings webhook lifecycle interface <https://developer.smartthings.com/docs/connected-services/lifecycles/>`_ on your behalf.  You just implement a single endpoint to accept the SmartApp webhook requests, and a single callback class where you define specialized behavior for the webhook events.  A clean `attrs <https://www.attrs.org/en/stable/>`_ object interface is exposed for use by your callback. The attrs interface has been designed to match the JSON interface documented by SmartThings.  If you have questions about the shape of the data or the way the lifecyle interface works, the SmartThings documentation is your best source of information.
 
 *Note: As of January 2025, I have migrated my home automation infrastructure from SmartThings to Home Assistant, so I no longer actively use this software. I will continue to maintain the library, keeping dependencies up-to-date and supporting new Python versions, etc.  Time permitting, I will also continue to accept GitHub issues for bug fixes and enhancement requests.  If you submit an issue, please keep in mind that I no longer have a SmartThings environment to test with, so I will expect you to coordinate with me on testing before I release any changes.*
 
@@ -209,7 +207,7 @@ want some exception handlers, etc.)::
 
 Then, make sure your web application is exposed on the public internet via
 https, and you are ready to follow the remaining setup steps in the
-`SmartThings documentation <https://developer-preview.smartthings.com/docs/connected-services/hosting/webhook-smartapp/>`_.
+`SmartThings documentation <https://developer.smartthings.com/docs/connected-services/hosting/webhook-smartapp/>`_.
 
 
 More Implementation Notes

--- a/src/smartapp/interface.py
+++ b/src/smartapp/interface.py
@@ -6,8 +6,8 @@ Classes that are part of the SmartApp interface.
 
 # For lifecycle class definitions, see:
 #
-#   https://developer-preview.smartthings.com/docs/connected-services/lifecycles/
-#   https://developer-preview.smartthings.com/docs/connected-services/configuration/
+#   https://developer.smartthings.com/docs/connected-services/lifecycles/
+#   https://developer.smartthings.com/docs/connected-services/configuration/
 #
 # There is not any public documentation about event structure, only the Javascript
 # reference implementation here:
@@ -17,10 +17,11 @@ Classes that are part of the SmartApp interface.
 # However, as of this writitng, even that reference implementation is not fully up-to-date
 # with the JSON that is being returned for some events I have examined in my testing.
 #
-# I have access to private documentation that shows all of the attributes.  However, that
-# documentation doesn't always make it clear which attributes will always be included and
-# which are optional.  As compromise, I have decided to maintain the actual events as
-# dicts rather than true objects.  See further discussion below by the Event class.
+# I previously had some access to private documentation showing all of the attributes.
+# However, that documentation did not always make it clear which attributes would always
+# be included and which were optional.  As compromise, I have decided to maintain the
+# actual events as dicts rather than true objects.  See further discussion below by
+# the Event class.
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping

--- a/src/smartapp/signature.py
+++ b/src/smartapp/signature.py
@@ -5,7 +5,7 @@ Verify HTTP signatures on SmartApp lifecycle event requests.
 """
 
 # This implements HTTP signature verification for the SmartApp lifecycle events.
-# See: https://developer-preview.smartthings.com/docs/connected-services/hosting/webhook-smartapp/
+# See: https://developer.smartthings.com/docs/connected-services/hosting/webhook-smartapp/
 #
 # SmartThings uses Joyent's HTTP signature scheme to sign all lifecycle events.
 # See: https://github.com/TritonDataCenter/node-http-signature/blob/master/http_signing.md

--- a/src/tests/smartapp/fixtures/samples/README.md
+++ b/src/tests/smartapp/fixtures/samples/README.md
@@ -1,6 +1,7 @@
 These sample JSON files were taken
-from the [SmartApp Lifecycles](https://developer-preview.smartthings.com/docs/connected-services/lifecycles/) page
-and the [Configuration](https://developer-preview.smartthings.com/docs/connected-services/configuration/) page.
+from the [SmartApp Lifecycles](https://developer.smartthings.com/docs/connected-services/lifecycles/) page
+and the [Configuration](https://developer.smartthings.com/docs/connected-services/configuration/) page in
+June of 2022.
 
 Nearly all of these samples had to be modified slightly, because the sample JSON is not actually valid.
 For instance, there are illegal and/or trailing commas. I fixed the syntax errors, and in one case added a `settings`
@@ -11,3 +12,12 @@ have.
 Other than that, I have left these requests as-is. The samples amount to interface documentation, since there
 is not actually a formal interface spec. On the plus side, the samples that we have for events from this source
 do actually line up with event interface, which I derived by looking at the code.
+
+It is entirely possible that the documentation has changed in some subtle way between June of 2022
+and when you are reading this, which causes one or more of the examples to be out-of-date.
+SmartThings does not appear to version this documentation.
+
+> **Note:** The original URLs used `developer-preview.smartthings.com`.  However, in October of
+> 2025, I realized that those URLs were broken, so I switched to `developer.smartthings.com`
+> instead.  The new documentation appears to be equivalent to the original documentation from 2022,
+> but there's no practical way to be certain.


### PR DESCRIPTION
While responding to issue #40, I realized that URLs for some of the SmartThings documentation were incorrect.  It looks like all that changed is `developer-preview.smartthings.com` -> `developer.smartthings.com`.  This PR corrects the URLs and makes some other minor clarifications.