### PR TITLE
Update to Pytest v9

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 0.9.2     unreleased
 
 	* Address Dependabot warnings for pygments and urllib3.
+	* Upgrade to Pytest v9 for new TOML syntax, strict mode, and Dependabot.
 	* Fix windows commands for external tools with PyCharm.
 	* Fix Sphinx autoapi to generate docs for source, not tests.
 	* Add support for Visual Studio Code as an IDE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
 [dependency-groups]
 dev = [
    "ruff (>=0.12.10,<1.0.0)",
-   "pytest (>=8.0.2,<9.0.0)",
+   "pytest (>=9.0.3,<10.0.0)",
    "pytest-testdox (>=3.1.0,<4.0.0)",
    "pytest-cov (>=7.1.0,<8.0.0)",
    "prek (>=0.2.1,<1.0.0)",
@@ -95,7 +95,8 @@ show_missing = false
 precision = 0
 omit = [ "src/tests/*" ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
+strict = true
 filterwarnings = [
     'error',  # turn all Python warnings into test failures, so they're hard to miss
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # SmartAppConverter

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -477,9 +477,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ dev = [
     { name = "colorama", specifier = ">=0.4.6,<1.0.0" },
     { name = "mypy", specifier = ">=1.6.0,<2.0.0" },
     { name = "prek", specifier = ">=0.2.1,<1.0.0" },
-    { name = "pytest", specifier = ">=8.0.2,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-testdox", specifier = ">=3.1.0,<4.0.0" },
     { name = "responses", specifier = ">=0.24.1,<1.0.0" },


### PR DESCRIPTION
Along with this update, I'm moving to native TOML configuration syntax, and enabling the new `strict` configuration option.  This also fixes a Dependabot warning about insecure temp file handling.  Based on [apologies PR #83](https://github.com/pronovic/apologies/pull/83).